### PR TITLE
Fix Getidentity NPE on nonexistent identity

### DIFF
--- a/src/main/java/plugins/WebOfTrust/fcp/GetIdentity.java
+++ b/src/main/java/plugins/WebOfTrust/fcp/GetIdentity.java
@@ -34,9 +34,11 @@ public class GetIdentity extends FCPBase {
 		{
 			if (rel.getEndNode().equals(identity)) direct_trust_rel = rel;
 		}
-		
+
+                if (identity != null) {
 		addIdentityReplyFields(direct_trust_rel, identity, "", true, trusterID);
 		addIdentityReplyFields(direct_trust_rel, identity, "0", true, trusterID); //0 suffix to make it similar to GetIdentities*
+                }
 		
 		return reply;
 	}

--- a/src/main/java/plugins/WebOfTrust/fcp/GetIdentity.java
+++ b/src/main/java/plugins/WebOfTrust/fcp/GetIdentity.java
@@ -35,11 +35,11 @@ public class GetIdentity extends FCPBase {
 			if (rel.getEndNode().equals(identity)) direct_trust_rel = rel;
 		}
 
-                if (identity != null) {
-		addIdentityReplyFields(direct_trust_rel, identity, "", true, trusterID);
-		addIdentityReplyFields(direct_trust_rel, identity, "0", true, trusterID); //0 suffix to make it similar to GetIdentities*
-                }
-		
+		if (identity != null) {
+			addIdentityReplyFields(direct_trust_rel, identity, "", true, trusterID);
+			addIdentityReplyFields(direct_trust_rel, identity, "0", true, trusterID); //0 suffix to make it similar to GetIdentities*
+		}
+
 		return reply;
 	}
 


### PR DESCRIPTION
In both cases `Param.Truster` is a local identity.

First input, things work as expected and the identity is returned:

```
FCPPluginMessage
Identifier=test
PluginName=plugins.WebOfTrust.WebOfTrust
Param.Message=GetIdentity
Param.Truster=uT0HBEQr17txtrkVt~auRBBFUtSubZQWeTAbIgXWMkc
Param.Identity=wHllqvhRlGLZZrXwqgsFFGbv2V9S33lq~-MTIN2FvOw
EndMessage
```

But second input, when the identity in `Param.Identity` does not exist:

```
FCPPluginMessage
Identifier=test
PluginName=plugins.WebOfTrust.WebOfTrust
Param.Message=GetIdentity
Param.Truster=uT0HBEQr17txtrkVt~auRBBFUtSubZQWeTAbIgXWMkc
Param.Identity=pxtehd-TmfJwyNUAW2Clk4pwv7Nshyg21NNfXcqzFv4
EndMessage
```

In `wrapper.log`:

```
jvm 1    | Failed to match message: GetIdentity with reply
jvm 1    | java.lang.NullPointerException
jvm 1    |  at plugins.WebOfTrust.fcp.GetIdentity.addIdentityReplyFields(GetIdentity.java:46)
jvm 1    |  at plugins.WebOfTrust.fcp.GetIdentity.handle(GetIdentity.java:38)
jvm 1    |  at plugins.WebOfTrust.FCPInterface.handle(FCPInterface.java:37)
jvm 1    |  at plugins.WebOfTrust.WebOfTrust.handle(WebOfTrust.java:272)
jvm 1    |  at freenet.pluginmanager.PluginTalker.sendSyncInternalOnly(PluginTalker.java:75)
jvm 1    |  at freenet.pluginmanager.PluginTalker$1.run(PluginTalker.java:61)
jvm 1    |  at freenet.support.PooledExecutor$MyThread.innerRun(PooledExecutor.java:247)
jvm 1    |  at freenet.support.PooledExecutor$MyThread.realRun(PooledExecutor.java:187)
jvm 1    |  at freenet.support.io.NativeThread.run(NativeThread.java:129)
```

And in FCP:

```
FCPPluginReply
PluginName=plugins.WebOfTrust.WebOfTrust
Identifier=test
Replies.Description=Could not match message with reply because of an exception: null
Replies.Message=Error
Replies.OriginalMessage=GetIdentity
EndMessage
```

This pull request makes the response for a nonexistent Identity be:

```
FCPPluginReply
PluginName=plugins.WebOfTrust.WebOfTrust
Identifier=test
Replies.Message=Identity
EndMessage
```
