### PR TITLE
Fix exiting loop after hitting maximum identities.

### DIFF
--- a/src/main/java/plugins/WebOfTrust/fcp/GetIdentitiesByPartialNickname.java
+++ b/src/main/java/plugins/WebOfTrust/fcp/GetIdentitiesByPartialNickname.java
@@ -92,7 +92,7 @@ public class GetIdentitiesByPartialNickname extends GetIdentity {
 					}
 				}
 
-				if (numIdentities > maxIdentities) continue;
+				if (numIdentities > maxIdentities) break;
 			}
 		}
 		


### PR DESCRIPTION
Checking a condition, then continuing as the last statement in a loop wouldn't do anything useful.
