### PR TITLE
 Add error on empty PartialNickname.

### DIFF
--- a/src/main/java/plugins/WebOfTrust/fcp/GetIdentitiesByPartialNickname.java
+++ b/src/main/java/plugins/WebOfTrust/fcp/GetIdentitiesByPartialNickname.java
@@ -26,6 +26,9 @@ public class GetIdentitiesByPartialNickname extends GetIdentity {
 
 		final String trusterID = input.get("Truster");
 		final String partialNickname = input.get("PartialNickname").trim();
+		if (partialNickname.isEmpty()) {
+			throw new IllegalArgumentException("PartialNickname cannot be empty.");
+		}
 		final String partialID = input.get("PartialID").trim();
 		final String context = input.get("Context");
 		final int maxIdentities;

--- a/src/main/java/plugins/WebOfTrust/fcp/GetIdentitiesByPartialNickname.java
+++ b/src/main/java/plugins/WebOfTrust/fcp/GetIdentitiesByPartialNickname.java
@@ -28,7 +28,7 @@ public class GetIdentitiesByPartialNickname extends GetIdentity {
 		final String partialNickname = input.get("PartialNickname").trim();
 		final String partialID = input.get("PartialID").trim();
 		final String context = input.get("Context");
-		int maxIdentities = 0; 
+		final int maxIdentities;
 		try {
 			maxIdentities = input.getInt("MaxIdentities");
 		} catch (FSParseException e) {


### PR DESCRIPTION
This message is easier to understand than `Cannot parse 'name:': Encountered "<EOF>" at line 1, column 5.`

Also make field final.
