### PR TITLE
integrate form passwords

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
 		<dependency>
 			<groupId>org.freenetproject</groupId>
 			<artifactId>fred</artifactId>
-			<version>0.7.5.1406</version>
+			<version>0.7.5.1450</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/plugins/WebOfTrust/pages/CypherQuery.java
+++ b/src/main/java/plugins/WebOfTrust/pages/CypherQuery.java
@@ -46,6 +46,7 @@ public class CypherQuery extends Toadlet implements LinkEnabledCallback {
 			HTMLNode form = new HTMLNode("form");
 			form.addAttribute("action", "");
 			form.addAttribute("method", "post");
+			form.addChild(Utils.getInput("hidden", "formPassword", ctx.getFormPassword()));
 			
 			HTMLNode textarea = new HTMLNode("textarea");
 			textarea.addAttribute("name", "query");

--- a/src/main/java/plugins/WebOfTrust/pages/IdentityManagement.java
+++ b/src/main/java/plugins/WebOfTrust/pages/IdentityManagement.java
@@ -94,6 +94,7 @@ public class IdentityManagement extends Toadlet implements LinkEnabledCallback {
 			form = new HTMLNode("form");
 			form.addAttribute("action", "restore.html");
 			form.addAttribute("method", "post");
+			form.addChild(Utils.getInput("hidden", "formPassword", ctx.getFormPassword()));
 			form.addChild(Utils.getInput("hidden", "action", "delete"));
 			form.addChild(Utils.getInput("hidden", "id", (String) own_vertex.getProperty(IVertex.ID)));
 			form.addChild(Utils.getInput("submit", "", "delete"));
@@ -107,6 +108,7 @@ public class IdentityManagement extends Toadlet implements LinkEnabledCallback {
 		form = new HTMLNode("form");
 		form.addAttribute("action", "restore.html");
 		form.addAttribute("method", "post");
+		form.addChild(Utils.getInput("hidden", "formPassword", ctx.getFormPassword()));
 		HTMLNode fieldset = new HTMLNode("fieldSet");
 		fieldset.addChild("legend", "Restore an identity");
 		fieldset.addChild(Utils.getInput("hidden", "action", "restore"));
@@ -124,6 +126,7 @@ public class IdentityManagement extends Toadlet implements LinkEnabledCallback {
 		form = new HTMLNode("form");
 		form.addAttribute("action", "restore.html");
 		form.addAttribute("method", "post");
+		form.addChild(Utils.getInput("hidden", "formPassword", ctx.getFormPassword()));
 		fieldset = new HTMLNode("fieldSet");
 		fieldset.addChild("legend", "Create an identity");
 		fieldset.addChild(Utils.getInput("hidden", "action", "create"));

--- a/src/main/java/plugins/WebOfTrust/pages/ShowIdentity.java
+++ b/src/main/java/plugins/WebOfTrust/pages/ShowIdentity.java
@@ -75,6 +75,7 @@ public class ShowIdentity extends Toadlet implements LinkEnabledCallback {
 			HTMLNode form = new HTMLNode("form");
 			form.addAttribute("action", "#");
 			form.addAttribute("method", "post");
+			form.addChild(Utils.getInput("hidden", "formPassword", ctx.getFormPassword()));
 			form.addChild(Utils.getInput("hidden", "action", "modify_properties"));
 			form.addChild(Utils.getInput("hidden", "identity", id));
 
@@ -133,6 +134,7 @@ public class ShowIdentity extends Toadlet implements LinkEnabledCallback {
 					HTMLNode context_form = new HTMLNode("form");
 					context_form.addAttribute("action", WebOfTrust.basePath+"/ShowIdentity?id="+id);
 					context_form.addAttribute("method", "post");
+					form.addChild(Utils.getInput("hidden", "formPassword", ctx.getFormPassword()));
 					context_form.addChild(Utils.getInput("submit", "", "Remove"));
 					context_form.addChild(Utils.getInput("hidden", "action", "remove_context"));
 					context_form.addChild(Utils.getInput("hidden", "context", context));
@@ -166,6 +168,7 @@ public class ShowIdentity extends Toadlet implements LinkEnabledCallback {
 				// TODO: why not use # here like above?
 				form.addAttribute("action", WebOfTrust.basePath+"/ShowIdentity?id="+id);
 				form.addAttribute("method", "post");
+				form.addChild(Utils.getInput("hidden", "formPassword", ctx.getFormPassword()));
 				HTMLNode fieldset = new HTMLNode("fieldset");
 				fieldset.addChild("legend", (String) own_vertex.getProperty(IVertex.NAME));
 				fieldset.addChild(Utils.getInput("hidden", "action", "set_trust"));
@@ -228,6 +231,7 @@ public class ShowIdentity extends Toadlet implements LinkEnabledCallback {
 						form = new HTMLNode("form");
 						form.addAttribute("action", WebOfTrust.basePath+"/ShowIdentity?id="+id + "#"+(i-1));
 						form.addAttribute("method", "post");
+						form.addChild(Utils.getInput("hidden", "formPassword", ctx.getFormPassword()));
 						form.addChild(Utils.getInput("submit", "", "Remove"));
 						form.addChild(Utils.getInput("hidden", "action", "remove_edge"));
 						form.addChild(Utils.getInput("hidden", "edge_id", Long.toString(edge.getId())));


### PR DESCRIPTION
Latest freenet version redirects to the same page after submitting any form in LCWoT if formPassword is missing. These commits add fromPassword input fields for every form and require at least Freenet version 1450 to support ctx.getFormPassword() .
